### PR TITLE
feat: verbosity features

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ the form `<region>:<table-name>`.
      requires an MFA token (can only be used with `--role-arn` **and** `--mfa-serial`).
    * `--slave-profile`, `--slave-role-arn`, `--slave-mfa-serial`, and `--slave-mfa-token`
      - see the subheading "Syncing Tables in Two Accounts" for more information.
+  * `--verbose` (or `-v`) enables additional verbose info & warnings to console logger on
+     specific item discrepancies and actions being performed.
+
 
 
 ### Syncing Tables in Two Accounts

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,8 +24,9 @@ argvOpts = {
       'slave-mfa-serial',
       'slave-mfa-token',
    ],
-   'boolean': [ 'write-missing', 'write-differing', 'scan-for-extra', 'delete-extra' ],
+   'boolean': [ 'write-missing', 'write-differing', 'scan-for-extra', 'delete-extra', 'verbose' ],
    'default': {
+      'verbose': false,
       'write-missing': false,
       'write-differing': false,
       'scan-for-extra': false,
@@ -34,6 +35,7 @@ argvOpts = {
    alias: {
       master: 'm',
       slaves: [ 's', 'slave' ],
+      verbose: 'v',
       'ignore-atts': [ 'ignore', 'ignore-att' ],
    },
 };
@@ -95,6 +97,7 @@ if (argsFailed) {
 }
 
 options = {
+   verbose: argv.verbose,
    writeMissing: argv['write-missing'],
    writeDiffering: argv['write-differing'],
    deleteExtra: argv['delete-extra'],


### PR DESCRIPTION
Taking at stab at https://github.com/silvermine/dynamodb-table-sync/issues/8

This does change the default program behavior to make it less verbose - I don't know if that's OK with you or not.

The (proposed) Default output:


> Master table us-west-2:attribute_values_preprod
> Approx. item count: 113567
> Key schema: { hash: 'id', range: 'key' }
> 
> Slave[1] table us-west-2:attribute_values_eric
> Approx. item count: 0
> Key schema: { hash: 'id', range: 'key' }
> 
> ......(1%)..........(2%)...........(3%)..........(4%)..........(5%)...........(6%)..........(7%)...........(8%)..........(9%)..........(10%)...........(11%)...........(12%)..........(13%)...........(14%)..........(15%)..........(16%)...........(17%)..........(18%)...........(19%)..........(20%)..........(21%)...........(22%)..........(23%)...........(24%)..........(25%)...........(26%)..........(27%)..........(28%)...........(29%)..........(30%)...........(31%)..........(32%)..........(33%)...........(34%)...........(35%)..........(36%)...........(37%)..........(38%)...........(39%)..........(40%)...........(41%)..........(42%)..........(43%)...........(44%)..........(45%)...........(46%)...........(47%)..........(48%)..........(49%)...........(50%)..........(51%)...........(52%)..........(53%)..........(54%)...........(55%)..........(56%)...........(57%)...........(58%)..........(59%)..........(60%)...........(61%)..........(62%)...........(63%)..........(64%)..........(65%)...........(66%)..........(67%)...........(68%)...........(69%)..........(70%)..........(71%)...........(72%)..........(73%)...........(74%)..........(75%)..........(76%)...........(77%)..........(78%)...........(79%)..........(80%)...........(81%)..........(82%)...........(83%)..........(84%)...........(85%)..........(86%)..........(87%)...........(88%)..........(89%)...........(90%)..........(91%)..........^C
> Synchronization completed. Stats:
> 
> us-west-2:attribute_values_eric
> Had 113567 items that were the same as the master
> (we did not scan the slave to find if it had "extra" items that the master does not have)
> Had 0 items that were different from the master
> Was missing 0 items that the master had
> 

With (proposed) `-v` or `--verbose` flags:

> Master table us-west-2:attribute_values_preprod
> Approx. item count: 113567
> Key schema: { hash: 'id', range: 'key' }
> 
> Slave[1] table us-west-2:attribute_values_eric
> Approx. item count: 0
> Key schema: { hash: 'id', range: 'key' }
> 
> Scanning us-west-2:attribute_values_preprod
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 50 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 100 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 150 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 200 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 250 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 300 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 350 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 400 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> Status: have compared 450 of approximately 113567 items from the master table to its slaves
> Comparing batch of 50 from master to 50 from slave us-west-2:attribute_values_eric
> ...
> 
> HUGE MULTI SCREEN PAGES
> ...
> 
> us-west-2:attribute_values_eric
> Had 113567 items that were the same as the master
> (we did not scan the slave to find if it had "extra" items that the master does not have)
> Had 0 items that were different from the master
> Was missing 0 items that the master had
> 

I also tweaked a couple `console.log` that I think should be `console.error` instead