### PR TITLE
Ensure non-zero exit status on AWS SDK exception.

### DIFF
--- a/src/Synchronizer.js
+++ b/src/Synchronizer.js
@@ -91,7 +91,12 @@ module.exports = Class.extend({
             self._abortScanning = true;
             console.error('Encountered an error while comparing tables', err, err.stack);
          })
-         .then(this._outputStats.bind(this));
+         .then(this._outputStats.bind(this))
+         .then(function() {
+            if (self._abortScanning) {
+                process.exit(1);
+            }
+         });
    },
 
    trackScanProgress: function(enabled, approxItems, f) {

--- a/src/Synchronizer.js
+++ b/src/Synchronizer.js
@@ -94,7 +94,7 @@ module.exports = Class.extend({
          .then(this._outputStats.bind(this))
          .then(function() {
             if (self._abortScanning) {
-                process.exit(1);
+               throw new Error();
             }
          });
    },


### PR DESCRIPTION
Exiting with a non-zero code would be helpful for automation / CI.

**NOTE**: this may not be the best / right way to approach this - added this change after a quick glance at the code.